### PR TITLE
Do not activate the tab after adding

### DIFF
--- a/LYTabView/LYTabBarView.swift
+++ b/LYTabView/LYTabBarView.swift
@@ -231,7 +231,6 @@ public class LYTabBarView: NSView {
             }
             self.invalidateIntrinsicContentSize()
         }
-        selectTabViewItem(item)
     }
 
     public func removeTabViewItem(tabviewItem : NSTabViewItem, animated : Bool = false) {


### PR DESCRIPTION
Hi Robin,

Is there a reason why you activate each tab after adding?

It could slow down the application if you try to open a lot of tabs in a time, because each tab must be selected first. Example from the real life: this can happen you want to restore open documents from previous session on start.

Also, calling lyTabView.addTabViewItem will activate the tab, but the animation will not be shown in that case.

Please let me know if I'm missing something.

Regards,
Dan
(fixed typo)
