### PR TITLE
Fix the autolayout issue with tab item content which doesn't fill the space

### DIFF
--- a/LYTabBarView Demo/Base.lproj/Main.storyboard
+++ b/LYTabBarView Demo/Base.lproj/Main.storyboard
@@ -783,7 +783,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="450" height="300"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WWx-uQ-PxG">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="WWx-uQ-PxG">
                                 <rect key="frame" x="207" y="142" width="37" height="17"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="qfi-xQ-ErS">
                                     <font key="font" metaFont="titleBar"/>

--- a/LYTabView/LYTabView.swift
+++ b/LYTabView/LYTabView.swift
@@ -51,6 +51,9 @@ public class LYTabView: NSView {
         stackView.leadingAnchor.constraintEqualToAnchor(tabBarView.leadingAnchor).active = true
         stackView.trailingAnchor.constraintEqualToAnchor(tabBarView.trailingAnchor).active = true
         
+        stackView.leadingAnchor.constraintEqualToAnchor(tabView.leadingAnchor).active = true
+        stackView.trailingAnchor.constraintEqualToAnchor(tabView.trailingAnchor).active = true
+ 
         tabView.setContentHuggingPriority(NSLayoutPriorityDefaultLow-10, forOrientation: .Vertical)
         tabBarView.setContentCompressionResistancePriority(NSLayoutPriorityDefaultHigh, forOrientation: .Vertical)
         tabBarView.setContentHuggingPriority(NSLayoutPriorityDefaultHigh, forOrientation: .Vertical)


### PR DESCRIPTION
Hi Robin,

I fixed the issue, which I mentioned here: https://github.com/robin/LYTabView/issues/1

Consider merging it into your repository if you agree with the fix.

P.S. I also slightly updated the demo to allow user to resize the window vertically in a case when content fills all space. It's not very important and you can avoid that.

Regards,
Dan
